### PR TITLE
Fix missing album art not being handled properly

### DIFF
--- a/mpcover/controler.py
+++ b/mpcover/controler.py
@@ -73,7 +73,7 @@ class Controler:
         else:
             logger.info("No password provided, assuming successful connection.")
 
-    def run(self, command: str, *args: str):
+    def run(self, command: str, *args: str) -> Iterable[bytes]:
         """
         Encode and send a command to the MPD server, then deocde and yeild
         the response.
@@ -114,6 +114,8 @@ class Controler:
                 # Gather response.
                 response = self.__connection.recv()
             except BrokenPipeError as error:
+                logger.error(error)
+            except OSError as error:
                 logger.error(error)
 
             # No respnse, try again.
@@ -220,11 +222,19 @@ class Controler:
             item += byte
             size -= 1
 
+        # Removed when fixing issue #6 in pull request #TODO. Missing album art
+        # causes MPD to not return anything, so this is a workaround. The accompanying
+        # change to the `run` method cathes the `OSErrror`s produced by the socket
+        # and in that case this method gets no repsonse, and an empty response is passed on.
+        """
         logger.critical(
             "Should not be possible to get to this point with a valid"
             " response from the server, exiting..."
         )
         sys.exit(203)
+        """
+
+        return []
 
     @generic_command
     def stats(self):


### PR DESCRIPTION
## Fix missing album art not being handled properly

When album art is missing, MPD sends no response causing a `socket.timeout` error.

## Changes

- [x] Catch potential socket errors when communicating with MPD.
- [x] Handle empty responses that are created when these errors are caught.
- [x] Added docstring to `Controler.__parse_response` method

---

Fixes #6
